### PR TITLE
Extend functionality for Facebook events

### DIFF
--- a/Classes/ComFacebookModule.m
+++ b/Classes/ComFacebookModule.m
@@ -343,15 +343,35 @@ NSTimeInterval meRequestTimeout = 180.0;
 }
 
 /**
- * JS example:
+ * JS examples:
  *
  * facebook.logCustomEvent('clappedHands');
+ * facebook.logCustomEvent('clappedHands', {times: 2});
  *
  */
 -(void)logCustomEvent:(id)args
 {
     NSString* event = [args objectAtIndex:0];
-    [FBAppEvents logEvent:event];
+    NSDictionary* eventData = nil;
+    
+    if ([args count] > 1) {
+        eventData = [args objectAtIndex:1];
+    }
+    
+    if([eventData isKindOfClass:[NSDictionary class]]){
+        [FBAppEvents logEvent:event parameters:eventData];
+    }else{
+        [FBAppEvents logEvent:event];
+    }
+}
+
+/**
+ * Alias for logCustomEvent
+ * Intended for exposing the method with the same name as in FB SDK.
+ */
+-(void)logEvent:(id)args
+{
+    [self logCustomEvent:args];
 }
 
 /**

--- a/Classes/ComFacebookModule.m
+++ b/Classes/ComFacebookModule.m
@@ -375,6 +375,43 @@ NSTimeInterval meRequestTimeout = 180.0;
 }
 
 /**
+ * JS examples:
+ *
+ * facebook.logPurchase(6.78, 'USD');
+ * facebook.logPurchase(6.78, 'USD', {userName: 'John Doe'});
+ *
+ */
+-(void)logPurchase:(id)args
+{
+    // We have to have at least amount and currency
+    if ([args count] < 2) {
+        NSLog(@"[DEBUG] Facebook logPurchase - Insufficient parameters");
+        return;
+    }
+
+    double amount = [TiUtils doubleValue:[args objectAtIndex:0] def: 0.0];
+    NSString* currency = [args objectAtIndex:1];
+    NSDictionary* eventData = nil;
+    
+    // Check if provided data is valid
+    if (amount == 0 || [currency length] == 0){
+        NSLog([NSString stringWithFormat:
+               @"[DEBUG] Facebook logPurchase - Provided parameters are invalid. Amount: %f - Currency: %@", amount, currency]);
+        return;
+    }
+    
+    if ([args count] > 2) {
+        eventData = [args objectAtIndex:2];
+    }
+    
+    if([eventData isKindOfClass:[NSDictionary class]]){
+        [FBAppEvents logPurchase:amount currency:currency parameters:eventData];
+    }else{
+        [FBAppEvents logPurchase:amount currency:currency];
+    }
+}
+
+/**
  * JS example:
  *
  * var facebook = require('facebook');

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Titanium Facebook Module
 Notes
 ------------
 * Install locally to your Titanium project, not globally. If you wish to install globally for all projects, you will need to modify module.xcconfig to point Xcode to the location of the FacebookSDK framework (in iphone/platform directory)
-* Note that the FacebookSDK.framework directory is the prebuilt Facebook SDK directly downloaded from Facebook, zero modifications. 
+* Note that the FacebookSDK.framework directory is the prebuilt Facebook SDK directly downloaded from Facebook, zero modifications.
 * Facebook is moving away from the native iOS login, and towards login through the Facebook app. The default behavior of this module is the same as in the Facebook SDK: app login with a fallback to webview. The advantages of the app login are: user control over individual permissions, and a uniform login experience over iOS, Android, and web. Additionally, the device login is quite prone to user error: for example, if the user declines to login initially with Facebook, then the next login will fail and the user needs to go into "Settings" on his phone and enable the app for Facebook. Many users will fail to do this. The only advantage of native device login is that it is faster. I recommend you leave the default as is, and if you do indeed elect nativeLogin then I recommend you do not request additional permissions beyond public_profile.
 * AppEvents are automatically logged. Check out the app Insights on Facebook. We can also log custom events for Insights.
 
@@ -55,7 +55,7 @@ where SomeName is exactly as appears in the Facebook developer settings page
 </array>
 ```
 *	`forceDialogAuth` - parameter unused.
-*	The login button functionality is for now removed. It makes no sense to use a button besides the Facebook branded buttons in the SDK, and that is left for the future. 
+*	The login button functionality is for now removed. It makes no sense to use a button besides the Facebook branded buttons in the SDK, and that is left for the future.
 *	Instead of "reauthorize" there is now requestNewReadPermissions and a separate requestNewPublishPermissions, as per the Facebook SDK. This provides much more flexibility and less nuisance to the users.
 
 Initialization
@@ -84,12 +84,12 @@ fb.initialize(timeoutInMs, nativeLogin); // initialize requires a timeout value 
 Events and error handling
 -------------------------
 
-The `login` and `logout` events work as in the original module. 
+The `login` and `logout` events work as in the original module.
 However, the error handling is now adhering to the new Facebook guidelines. Here is how to handle `login` events:
 ```javascript
 fb.addEventListener('login', function(e) {
 	if(e.success) {
-		// do your thang.... 
+		// do your thang....
 	} else if (e.cancelled) {
 		// login was cancelled, just show your login UI again
 	} else if (e.error) {
@@ -129,7 +129,7 @@ Use it! You don't need permissions, you don't even need the user to be logged in
 *	To post a graph action call:
 
 ```javascript
-fb.share({url: someUrl, namespaceObject: 'myAppnameSpace:graphObject', objectName: 'graphObject', imageUrl: someImageUrl, 
+fb.share({url: someUrl, namespaceObject: 'myAppnameSpace:graphObject', objectName: 'graphObject', imageUrl: someImageUrl,
 		title: aTitle, description: blahBlah, namespaceAction: 'myAppnameSpace:actionType', placeId: facebookPlaceId}`
 ```
 For the graph action apparently only placeId is optional.
@@ -138,7 +138,7 @@ Like Button
 -----------
 
 We can create a Like button just like any other view, with specific parameters documented in Facebook docs. Note there is no completion callback or event, and Facebook policies state "If you use the Like button on iOS or Android, don’t collect or use any information from it."
- 
+
 ```
 var likeButton = fbModule.createLikeButton({
 	top: 10,
@@ -170,10 +170,10 @@ fb.requestNewReadPermissions(['read_stream','user_hometown', etc...], function(e
  	}
 });
 ```
- 
+
 requestNewPublishPermissions
 ----------------------------
- 
+
  You must use the audience constants from the module, either `audienceNone`, `audienceOnlyMe`, `audienceFriends`, or `audienceEveryone`.
  Note that it is not an error for the user to 'Skip' your requested permissions, so you should check the module's permissions property following the call.
 
@@ -196,18 +196,24 @@ requestWithGraphPath
 Same as the original Titanium Facebook module. However, there is automatic error handling.
 So in case of error only alert the user if `error == 'An unexpected error'`, everything else was already handled for you.
 
+Events logging
+--------------
+
+More info about [FBAppEvents](https://developers.facebook.com/docs/reference/ios/3.9/class/FBAppEvents)
+
+**logEvent** (*alias for logCustomEvent*)
+```
+fb.logEvent('handsClapped');
+fb.logEvent('handsClapped', {times: 12});
+```
+
 To do
 -------
 *	Facebook branded buttons - use the SDK implementation or don't do it.
 *	[Share sheet](https://developers.facebook.com/docs/ios/ios-6/#nativepostcontroller) - it's more lightweight than the Share Dialog, but also with many less features. Some apps use Share Dialog (e.g. Pintrest), some the Share Sheet (e.g. Foodspotting).
 *	Additional dialogs. But why?!?!??!? They are web based, require permissions, few good apps use them today. Just use the Share Dialog, or Share Sheet, or don't bother, in my opinion.
 
-Custom App Events
------------------
-```
-fb.logCustomEvent('handsClapped'); // Pass a string for the event name, view the events on Facebook Insights
-```
-	
+
 Feel free to comment and help out! :)
 -------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ fb.logEvent('handsClapped');
 fb.logEvent('handsClapped', {times: 12});
 ```
 
+**logPurchase**
+```
+fb.logPurchase(6.78, 'USD');
+fb.logPurchase(6.78, 'USD', {userName: 'John Doe'});
+```
+
 To do
 -------
 *	Facebook branded buttons - use the SDK implementation or don't do it.

--- a/titanium.xcconfig
+++ b/titanium.xcconfig
@@ -4,13 +4,13 @@
 // OF YOUR TITANIUM SDK YOU'RE BUILDING FOR
 //
 //
-TITANIUM_SDK_VERSION = 3.5.0.RC
+TITANIUM_SDK_VERSION = 3.5.0.GA
 
 
 //
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
-TITANIUM_SDK = /Users/Marek/Library/Application Support/Titanium/mobilesdk/osx/3.5.0.RC
+TITANIUM_SDK = ~/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
 TITANIUM_BASE_SDK = "$(TITANIUM_SDK)/iphone/include"
 TITANIUM_BASE_SDK2 = "$(TITANIUM_SDK)/iphone/include/TiCore"
 HEADER_SEARCH_PATHS= $(TITANIUM_BASE_SDK) $(TITANIUM_BASE_SDK2)


### PR DESCRIPTION
Extended the functionality for supporting additional event data when sending custom app events. This change is backwards compatible with previous logCustomEvent implementation.
Also, logPurchase support was added.

Further info:
https://developers.facebook.com/docs/reference/ios/3.9/class/FBAppEvents
- logEvent:parameters:
- logPurchase:currency:parameters:
